### PR TITLE
Fix compatibility with marshmallow and typo

### DIFF
--- a/fuo_local/provider.py
+++ b/fuo_local/provider.py
@@ -90,11 +90,11 @@ def add_song(fpath, g_songs, g_artists, g_albums):
         url=fpath,
         duration=metadata.info.length * 1000  # milesecond
     ))
-    schema = EasyMP3MetadataSongSchema(strict=True)
+    schema = EasyMP3MetadataSongSchema()
     try:
-        data, _ = schema.load(metadata_dict)
+        data = schema.load(metadata_dict)
     except ValidationError:
-        logger.exeception('解析音乐文件({}) 元数据失败'.format(fpath))
+        logger.exception('解析音乐文件({}) 元数据失败'.format(fpath))
         return
 
     # NOTE: use {title}-{artists_name}-{album_name} as song identifier

--- a/fuo_local/schemas.py
+++ b/fuo_local/schemas.py
@@ -9,15 +9,15 @@ class EasyMP3MetadataSongSchema(Schema):
     """EasyMP3 metadata"""
     url = fields.Str(required=True)
     duration = fields.Float(required=True)
-    title = fields.Str(required=True, missing=DEFAULT_TITLE)
-    artists_name = fields.Str(required=True, load_from='artist',
+    title = fields.Str(missing=DEFAULT_TITLE)
+    artists_name = fields.Str(data_key='artist',
                               missing=DEFAULT_ARTIST_NAME)
-    album_name = fields.Str(required=True, load_from='album',
+    album_name = fields.Str(data_key='album',
                             missing=DEFAULT_ALBUM_NAME)
-    album_artist_name = fields.Str(required=True, load_from='albumartist',
+    album_artist_name = fields.Str(data_key='albumartist',
                                    missing=DEFAULT_ARTIST_NAME)
-    track = fields.Str(load_from='tracknumber', missing='1/1')
-    disc = fields.Str(load_from='discnumber', missing='1/1')
+    track = fields.Str(data_key='tracknumber', missing='1/1')
+    disc = fields.Str(data_key='discnumber', missing='1/1')
     date = fields.Str(missing='')
     genre = fields.Str(missing='')
 


### PR DESCRIPTION
I just installed feeluown-local via pip. Marshmallow 3.0b10 is installed by default, and it causes a few compatibility issues with the present code.

1. In marshmallow 3.0, Schemas are always strict, so `EasyMP3MetadataSongSchema(strict=True)` raises a TypeError.
2. The `load_from` keyword argument in fields is changed to `data_key`.
3. Fields marked as `required` will always raise a `ValidationError` when the field is missing, even when `missing` or `default` is set.
4. `Schema.load` generates only one variable.

Besides, a typo of 'logger.exeception' was also fixed in this PR.
